### PR TITLE
feat: argsIgnorePattern to no-unused-vars config

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -57,6 +57,12 @@ module.exports = {
         'no-trailing-spaces': [
             eslintRuleSettings.error
         ],
+        'no-unused-vars': [
+            eslintRuleSettings.error,
+            {
+                argsIgnorePattern: '^_'
+            }
+        ],
         'object-curly-newline': [
             eslintRuleSettings.off,
             'always',

--- a/lib/rules/recommended.js
+++ b/lib/rules/recommended.js
@@ -43,6 +43,12 @@ module.exports = {
         'no-trailing-spaces': [
             eslintRuleSettings.error
         ],
+        'no-unused-vars': [
+            eslintRuleSettings.error,
+            {
+                argsIgnorePattern: '^_'
+            }
+        ],
         quotes: [
             eslintRuleSettings.error,
             'single'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swellaby/eslint-config",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "Our eslint configurations",
   "license": "MIT",
   "main": "lib/bundles/node.js",

--- a/test/rules/all.js
+++ b/test/rules/all.js
@@ -87,6 +87,13 @@ suite('rules:all Suite:', () => {
         assert.deepEqual(noTrailingSpacesRule[0], testutils.eslintRuleSettings.error);
     });
 
+    test('Should add underscore exclusion on no-unused vars', () => {
+        const noUnusedVars = config.rules[testutils.eslintRuleNames.noUnusedVars];
+        assert.deepEqual(noUnusedVars.length, 2);
+        assert.deepEqual(noUnusedVars[0], testutils.eslintRuleSettings.error);
+        assert.deepEqual(noUnusedVars[1], {argsIgnorePattern: '^_'});
+    });
+
     test('Should disable object-curly-newline rule', () => {
         const objectCurlyNewlineRule = config.rules[testutils.eslintRuleNames.objectCurlyNewline];
         // assert.deepEqual(objectCurlyNewlineRule.length, 1);

--- a/test/rules/recommended.js
+++ b/test/rules/recommended.js
@@ -57,6 +57,13 @@ suite('rules:recommended Suite:', () => {
         assert.deepEqual(noTrailingSpacesRule[0], testutils.eslintRuleSettings.error);
     });
 
+    test('Should add underscore exclusion on no-unused vars', () => {
+        const noUnusedVars = config.rules[testutils.eslintRuleNames.noUnusedVars];
+        assert.deepEqual(noUnusedVars.length, 2);
+        assert.deepEqual(noUnusedVars[0], testutils.eslintRuleSettings.error);
+        assert.deepEqual(noUnusedVars[1], {argsIgnorePattern: '^_'});
+    });
+
     test('Should set quotes rule to single quote', () => {
         const quotesRule = config.rules.quotes;
         assert.deepEqual(quotesRule.length, 2);

--- a/testutils.js
+++ b/testutils.js
@@ -17,6 +17,7 @@ module.exports = {
         noConsole: 'no-console',
         noMagicNumbers: 'no-magic-numbers',
         noTrailingSpaces: 'no-trailing-spaces',
+        noUnusedVars: 'no-unused-vars',
         objectCurlyNewline: 'object-curly-newline',
         oneVar: 'one-var',
         paddedBlocks: 'padded-blocks',


### PR DESCRIPTION
## Overview
This PR:
- [X] Includes Rule Configuration changes
- [ ] Includes Environment Configuration changes
- [ ] Includes Override Configuration changes
- [ ] Includes Bundle Configuration changes
- [ ] Includes misc changes (metadata, repo config, etc.)

### Doc Updates
- [ ] If this PR includes any changes to eslint configurations, the corresponding documentation was also updated.

### Issues Completed
<!-- Delete this section if there's no corresponding issues closed/completed in this PR -->
- Closes #8 

## Details
<!-- Enter any specific details here if you are changing rule config, add/removing rules, including why, etc. -->
Adds argIgnorePattern to the no-unused-var rule so that the `_` prefix can be used to exclude certain instances where an unused var is required, such as in certain mocks/stubs

CC - @calebcartwright @beverts312 @traviskosarek
